### PR TITLE
Improve display repaint in headless models

### DIFF
--- a/src/main/ChildModel.scala
+++ b/src/main/ChildModel.scala
@@ -87,6 +87,5 @@ abstract class ChildModel(val parentWorkspace: Workspace, val modelID: Int)  {
       else
         SwingUtilities.invokeLater(() => f)
     }
-
 }
 

--- a/src/main/LevelSpace.scala
+++ b/src/main/LevelSpace.scala
@@ -59,7 +59,6 @@ class LevelSpace extends DefaultClassManager { // This can be accessed by both t
     primitiveManager.addPrimitive("model-exists?", new ModelExists(this))
     primitiveManager.addPrimitive("reset", new Reset(this))
     primitiveManager.addPrimitive("path-of", new Path(this))
-    primitiveManager.addPrimitive("display", new UpdateView(this))
     primitiveManager.addPrimitive("show", new Show(this))
     primitiveManager.addPrimitive("hide", new Hide(this))
     primitiveManager.addPrimitive("show-all", new ShowAll(this))

--- a/src/main/Prims.scala
+++ b/src/main/Prims.scala
@@ -229,10 +229,6 @@ class Hide(ls: LevelSpace) extends ModelCommand(ls, _.hide())
 class ShowAll(ls: LevelSpace) extends ModelCommand(ls, _.showAll())
 class HideAll(ls: LevelSpace) extends ModelCommand(ls, _.hideAll())
 class Close(ls: LevelSpace) extends ModelCommand(ls, ls.closeModel)
-class UpdateView(ls: LevelSpace) extends ModelCommand(ls, {
-  case hm: HeadlessChildModel => hm.updateView()
-  case _ =>
-})
 class Name(ls: LevelSpace) extends ModelReporter(ls, Syntax.StringType, _.name)
 class Path(ls: LevelSpace) extends ModelReporter(ls, Syntax.StringType, _.path)
 class UsesLS(ls: LevelSpace) extends ModelReporter(ls, Syntax.BooleanType, (model: ChildModel) => Boolean.box(model.usesLevelSpace))

--- a/src/main/ViewFrame.scala
+++ b/src/main/ViewFrame.scala
@@ -10,8 +10,8 @@ import org.nlogo.window.Events.{AddJobEvent, CompileMoreSourceEvent, CompiledEve
 import org.nlogo.window.JobWidget
 
 class ViewFrame(ws: HeadlessWorkspace) extends JFrame with CompileMoreSourceEvent.Handler with AddJobEvent.Handler {
-  val viewPanel = new JPanel() {
-    override def paintComponent(g: Graphics) = {
+  private val viewPanel = new JPanel() {
+    override def paintComponent(g: Graphics): Unit = {
       ws.renderer.exportView(g.asInstanceOf[Graphics2D], ws)
     }
   }
@@ -27,11 +27,6 @@ class ViewFrame(ws: HeadlessWorkspace) extends JFrame with CompileMoreSourceEven
   val panel = new HeadlessPanel(ws, viewContainer)
   getContentPane.add(panel)
   pack()
-
-  new Timer(1000 / 30, (e: ActionEvent) => {
-    viewPanel.repaint()
-    new PeriodicUpdateEvent().raise(ViewFrame.this)
-  }).start()
 
   def handle(e: CompileMoreSourceEvent): Unit = {
     val owner = e.owner

--- a/src/main/ViewFrame.scala
+++ b/src/main/ViewFrame.scala
@@ -8,12 +8,11 @@ import org.nlogo.core.CompilerException
 import org.nlogo.headless.HeadlessWorkspace
 import org.nlogo.window.Events.{AddJobEvent, CompileMoreSourceEvent, CompiledEvent, PeriodicUpdateEvent}
 import org.nlogo.window.JobWidget
+import org.nlogo.render.Renderer
 
 class ViewFrame(ws: HeadlessWorkspace) extends JFrame with CompileMoreSourceEvent.Handler with AddJobEvent.Handler {
   private val viewPanel = new JPanel() {
-    override def paintComponent(g: Graphics): Unit = {
-      ws.renderer.exportView(g.asInstanceOf[Graphics2D], ws)
-    }
+    override def paintComponent(g: Graphics): Unit = ws.renderer.paint(g.asInstanceOf[Graphics2D], ws)
   }
 
   val viewContainer = new JPanel

--- a/src/main/ViewFrame.scala
+++ b/src/main/ViewFrame.scala
@@ -12,7 +12,9 @@ import org.nlogo.render.Renderer
 
 class ViewFrame(ws: HeadlessWorkspace) extends JFrame with CompileMoreSourceEvent.Handler with AddJobEvent.Handler {
   private val viewPanel = new JPanel() {
-    override def paintComponent(g: Graphics): Unit = ws.renderer.paint(g.asInstanceOf[Graphics2D], ws)
+    override def paintComponent(g: Graphics): Unit = ws.world.synchronized {
+      ws.renderer.paint(g.asInstanceOf[Graphics2D], ws)
+    }
   }
 
   val viewContainer = new JPanel


### PR DESCRIPTION
- Headless models now use the normal `requestDisplayUpdate` mechanism to trigger repaints, meaning that they correctly respond to `display` and `tick`
- Headless models no longer use a repeating Timer for repaints, so there will be fewer unecessary repaints
- Headless models repaints are rate limited to every 30 ms, reducing the number of repaints through collation