### PR TITLE
Add local stack traces to child model errors

### DIFF
--- a/src/main/ChildModel.scala
+++ b/src/main/ChildModel.scala
@@ -46,7 +46,7 @@ abstract class ChildModel(val parentWorkspace: Workspace, val modelID: Int)  {
   def frameTitle = s"$name (LevelSpace model #$modelID)"
   def frame: Option[JFrame]
 
-  def setSpeed(d: Double)
+  def setSpeed(d: Double): Unit
   def workspace: AbstractWorkspaceScala
 
   // can't change once model is loaded

--- a/src/main/ErrorUtils.scala
+++ b/src/main/ErrorUtils.scala
@@ -2,9 +2,16 @@ package org.nlogo.ls
 
 import org.nlogo.api.ExtensionException
 import org.nlogo.nvm.HaltException
+import org.nlogo.nvm.EngineException
 
 object ErrorUtils {
   def wrap(modelID: Int, name: String, e: Exception): ExtensionException = e match {
+    case e: EngineException => new ExtensionException(
+      s"""Model $modelID ($name) encountered an error${e.responsibleInstruction.map(instr => s" at expression '${instr.fullSource}'").getOrElse("")}:
+          |
+          |${e.runtimeErrorMessage}""".stripMargin
+    , e)
+
     case h: HaltException => throw h
     case e: Exception => new ExtensionException(s"Model $modelID ($name) encountered an error: ${e.getMessage}", e)
   }

--- a/tests.txt
+++ b/tests.txt
@@ -101,12 +101,36 @@ ls-path-of
   member? "extensions/ls/test/Blank.nlogo" ls:path-of 0 => true
   member? "extensions/ls/test/Blank.nlogo" first ls:path-of [0] => true
 
-ls-errors-propogate
+*ls-errors-propogate
   extensions [ ls ]
   O> ls:create-models 1 "extensions/ls/test/Blank.nlogo"
-  O> ls:ask 0 [ error "hi" ] => ERROR Extension exception: Model 0 (Blank.nlogo) encountered an error: hi
-  [ 1 / count turtles ] ls:of 0 => ERROR Extension exception: Model 0 (Blank.nlogo) encountered an error: Division by zero.
-  ls:report 0 [ 1 / count turtles ] => ERROR Extension exception: Model 0 (Blank.nlogo) encountered an error: Division by zero.
+
+  O> ls:ask 0 [ error "hi" ] => STACKTRACE Extension exception: Model 0 (Blank.nlogo) encountered an error at expression 'error "hi"':\
+  \
+  hi\
+  error while observer running ERROR\
+    called by (anonymous command: [ error "hi" ])\
+    called by (anonymous command: [ [__lsargs] -> __apply [ error "hi" ] __lsargs ])\
+    called by procedure __EVALUATOR\
+  error while observer running LS:ASK\
+    called by procedure __EVALUATOR
+
+  [ 1 / count turtles ] ls:of 0 => STACKTRACE Extension exception: Model 0 (Blank.nlogo) encountered an error at expression '1 / count turtles':\
+  \
+  Division by zero.\
+  error while observer running /\
+    called by procedure __EVALUATOR\
+  error while observer running LS:OF\
+    called by procedure __EVALUATOR
+
+  ls:report 0 [ 1 / count turtles ] => STACKTRACE Extension exception: Model 0 (Blank.nlogo) encountered an error at expression '1 / count turtles':\
+  \
+  Division by zero.\
+  error while observer running /\
+    called by procedure __EVALUATOR\
+  error while observer running LS:REPORT\
+    called by procedure __EVALUATOR
+
 
 ls-cant-report-agentsets
   extensions [ ls ]


### PR DESCRIPTION
Adds netlogo code stack traces relative to child model code to child model errors:

![image](https://user-images.githubusercontent.com/28215/215288947-b840e7a3-4202-4b64-a51a-dc771fff7bdf.png)

I would've liked to have had line numbers in there as well, but didn't want to take the time to figure out how to convert from character number to line number, so opted for including the expression with arguments to help disambiguate in larger procedures. Obviously, jumping straight to the source point when GUI would be ideal, but this is still a significant improvement.